### PR TITLE
Bump Image dependency to v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [0.2.1]
 
 * `Exporter` class exposes now `frames`.
+*  Bump `image` dependency to ^4.0.17
 
 ## [0.2.0]
 

--- a/lib/src/exporter.dart
+++ b/lib/src/exporter.dart
@@ -1,7 +1,6 @@
 import 'dart:ui' as ui show ImageByteFormat;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:image/image.dart' as image;
 import 'package:screen_recorder/src/frame.dart';
 
@@ -45,8 +44,7 @@ class Exporter {
   }
 
   static Future<List<int>?> _exportGif(List<RawFrame> frames) async {
-    final animation = image.Animation();
-    animation.backgroundColor = Colors.transparent.value;
+    final encoder = image.GifEncoder();
     for (final frame in frames) {
       final iAsBytes = frame.image.buffer.asUint8List();
       final decodedImage = image.decodePng(iAsBytes);
@@ -55,10 +53,10 @@ class Exporter {
         print('Skipped frame while enconding');
         continue;
       }
-      decodedImage.duration = frame.durationInMillis;
-      animation.addFrame(decodedImage);
+      decodedImage.frameDuration = frame.durationInMillis;
+      encoder.addFrame(decodedImage);
     }
-    return image.encodeGifAnimation(animation);
+    return encoder.finish();
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  image: ^4.0.17
+  image: ^4.1.7
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  image: ^3.0.2
+  image: ^4.0.17
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR bumps the `Image` dependency to v4.

Fixes https://github.com/Baseflow/screenrecorder/issues/39

It would be nice to have a release after this is merged.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/screenrecorder/blob/main/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning